### PR TITLE
Correcao de erro de digitacao na funcao mensagem do typed racket

### DIFF
--- a/04-tipos-de-dados/notas-de-aula.md
+++ b/04-tipos-de-dados/notas-de-aula.md
@@ -640,14 +640,14 @@ A linguagem racket possui uma variante com tipagem estática de dados, a qual pe
   (cond
     [(string? estado) 
      "A tarefa está em execução"]
-    [(Sucesso? estado)
+    [(sucesso? estado)
      (format "A tarefa finalizou com sucesso (~as): ~a."
-             (Sucesso-duracao estado)
-             (Sucesso-msg estado))]
-    [(Erro? estado)
+             (sucesso-duracao estado)
+             (sucesso-msg estado))]
+    [(erro? estado)
      (format "A tarefa falhou (erro ~a): ~a."
-             (Erro-codigo estado)
-             (Erro-msg estado))]))
+             (erro-codigo estado)
+             (erro-msg estado))]))
 ```
 
 


### PR DESCRIPTION
Acabei deixando um errinho nos slides do typed racket, as funções para as structs eram minúsculas e copiei e colei do editor o código com elas maiúsculas. Segue a correção.